### PR TITLE
Fix error in http response type

### DIFF
--- a/sqs/endpoint.bal
+++ b/sqs/endpoint.bal
@@ -89,7 +89,7 @@ public client class Client {
         http:Request|error request = self.generatePOSTRequest(amzTarget, endpoint, 
                                      self.buildPayload(parameters));
         if (request is http:Request) {
-            var httpResponse = self.clientEp->post(endpoint, request);
+            http:Response|error httpResponse = self.clientEp->post(endpoint, request);
             xml|ResponseHandleFailed response = handleResponse(httpResponse);
             if (response is xml){
                 return xmlToCreatedQueueUrl(response);
@@ -142,7 +142,7 @@ public client class Client {
             http:Request|error request = self.generatePOSTRequest(amzTarget, queueResourcePath, 
                                          self.buildPayload(parameters));
             if (request is http:Request) {
-                var httpResponse = self.clientEp->post(queueResourcePath, request);
+                http:Response|error httpResponse = self.clientEp->post(queueResourcePath, request);
                 xml|ResponseHandleFailed response = handleResponse(httpResponse);
                 if (response is xml){
                                         log:printInfo(response.toString());
@@ -211,7 +211,7 @@ public client class Client {
         http:Request|error request = self.generatePOSTRequest(amzTarget, queueResourcePath,
                                      self.buildPayload(parameters));
         if (request is http:Request) {
-            var httpResponse = self.clientEp->post(queueResourcePath, request);
+            http:Response|error httpResponse = self.clientEp->post(queueResourcePath, request);
             xml|ResponseHandleFailed response = handleResponse(httpResponse);
             if (response is xml){
                 InboundMessage[]|DataMappingError result = xmlToInboundMessages(response);
@@ -246,7 +246,7 @@ public client class Client {
             http:Request|error request = self.generatePOSTRequest(amzTarget, queueResourcePath, 
                                          self.buildPayload(parameters));
             if (request is http:Request) {
-                var httpResponse = self.clientEp->post(queueResourcePath, request);
+                http:Response|error httpResponse = self.clientEp->post(queueResourcePath, request);
                 xml|ResponseHandleFailed response = handleResponse(httpResponse);
                 if (response is xml) {
                     return isXmlDeleteResponse(response);
@@ -274,7 +274,7 @@ public client class Client {
         http:Request|error request = self.generatePOSTRequest(amzTarget, queueResourcePath, 
                                      self.buildPayload(parameters));
         if (request is http:Request) {
-            var httpResponse = self.clientEp->post(queueResourcePath, request);
+            http:Response|error httpResponse = self.clientEp->post(queueResourcePath, request);
             xml|ResponseHandleFailed response = handleResponse(httpResponse);
             if (response is xml) {
                 return isXmlDeleteQueueResponse(response);


### PR DESCRIPTION
## Purpose
> Fix error where http response type as `http:Response|error' since 'var' is used earlier and is not supported in beta.

## Goals
> Fix build failure caused in nightly build
