### PR TITLE
Bump versions for slbeta3 in master branch 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,4 +27,5 @@ jobs:
                   args:
                       push
               env:
+                  WORKING_DIR: ./sqs
                   BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This connector provides operations for connecting and interacting with Amazon SQ
 
     > **Note:** Set the JAVA_HOME environment variable to the path name of the directory in which you installed JDK.
 
-2. Download and install [Ballerina Swan Lake Beta2](https://ballerina.io/). 
+2. Download and install [Ballerina Swan Lake Beta3](https://ballerina.io/). 
 
 ### Building the source
 Execute the following commands to build from the source:

--- a/sqs/Dependencies.toml
+++ b/sqs/Dependencies.toml
@@ -1,44 +1,44 @@
 [[dependency]]
 org = "ballerina"
 name = "os"
-version = "0.8.0-beta.2"
+version = "0.8.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "log"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "url"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "random"
-version = "0.10.0-beta.2"
+version = "0.10.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "time"
-version = "2.0.0-beta.2"
+version = "2.0.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "http"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "jballerina.java.arrays"
-version = "0.10.0-beta.2"
+version = "0.10.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "crypto"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "io"
-version = "0.6.0-beta.2"
+version = "0.6.0-beta.3"

--- a/sqs/Package.md
+++ b/sqs/Package.md
@@ -8,7 +8,7 @@ This package provides the capability to access Amazon SQS and it provides capabi
 ### Compatibility
 |                    | Version         |
 |--------------------|-----------------|
-| Ballerina Language | Swan Lake Beta2 |
+| Ballerina Language | Swan Lake Beta3 |
 | Amazon SQS API     | 2012-11-05      |
 
 ## Report issues


### PR DESCRIPTION
## Purpose
- Bump version to slbeta3 in Dependencies.toml, README.md and Package.md

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 11
Ballerina SLBeta3-SNAPSHOT
