### PR TITLE
Refactor GraalVM Check workflow with template

### DIFF
--- a/.github/workflows/build-with-bal-test-native.yml
+++ b/.github/workflows/build-with-bal-test-native.yml
@@ -1,40 +1,19 @@
 name: GraalVM Check
 
 on:
-  schedule:
-    - cron: '30 18 * * *'
+  pull_request:
+    branches:
+      - master
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Set up GraalVM
-        uses: graalvm/setup-graalvm@v1
-        with:
-          java-version: '17'
-          distribution: 'graalvm-community'
-          set-java-home: false
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check GraalVM installation
-        run: |
-          echo "GRAALVM_HOME: ${{ env.GRAALVM_HOME }}"
-          echo "JAVA_HOME: ${{ env.JAVA_HOME }}"
-          native-image --version
-
-      - name: Set Up Ballerina
-        uses: ballerina-platform/setup-ballerina@v1.1.3
-        with:
-          version: latest
-
-      - name: Run Ballerina tests using the native executable
-        working-directory: ./ballerina
-        run: bal test --graalvm
-        env:
-          ACCESS_KEY_ID: ${{ secrets.ACCESS_KEY_ID }}
-          SECRET_ACCESS_KEY: ${{ secrets.SECRET_ACCESS_KEY }}
-          REGION: ${{ secrets.REGION }}
+  call_stdlib_workflow:
+    name: Run StdLib Workflow
+    if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository_owner == 'ballerina-platform') }}
+    uses: ballerina-platform/ballerina-library/.github/workflows/build-with-bal-test-graalvm-connector-template.yml@main
+    secrets: inherit
+ 


### PR DESCRIPTION
# Description

> $Subject

- Use the template from Library repository
- Use Java 21 for GraalVM check
- Enable GraalVM check on pull request builds
- Disable daily GraalVM checks