### PR TITLE
Update to SQS to Use  `ErrorDetails` Record

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -9,6 +9,13 @@ icon="icon.png"
 license=["Apache-2.0"]
 distribution = "2201.12.0"
 
+# TODO: Remove the `repository` entry once ballerinax/aws 0.2.0 is published to Ballerina Central.
+[[dependency]]
+org = "ballerinax"
+name = "aws"
+version = "0.2.0"
+repository = "local"
+
 [platform.java21]
 graalvmCompatible = true
 

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -9,13 +9,6 @@ icon="icon.png"
 license=["Apache-2.0"]
 distribution = "2201.12.0"
 
-# TODO: Remove the `repository` entry once ballerinax/aws 0.2.0 is published to Ballerina Central.
-[[dependency]]
-org = "ballerinax"
-name = "aws"
-version = "0.2.0"
-repository = "local"
-
 [platform.java21]
 graalvmCompatible = true
 

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -111,7 +111,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "aws"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/errors.bal
+++ b/ballerina/errors.bal
@@ -14,19 +14,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-# Represents a AWS SQS  distinct error.
-public type Error distinct error<ErrorDetails>;
+import ballerinax/aws;
 
-# The error details type for the AWS SQS  module.
-public type ErrorDetails record {|
-    # The HTTP status code for the error
-    int httpStatusCode?;
-    # The HTTP status text returned from the service
-    string httpStatusText?;
-    # The error code associated with the response
-    string errorCode?;
-    # The human-readable error message provided by the service
-    string errorMessage?;
-    # The unique identifier of the request assigned by the service
-    string requestId?;
-|};
+# Represents a AWS SQS distinct error. The fields of `aws:ErrorDetails` are populated
+# when the failure originates from an AWS SQS service call, and are left unset when the
+# failure occurs before a response is received (e.g. an invalid configuration).
+public type Error distinct error<aws:ErrorDetails>;

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -764,13 +764,6 @@ function testGetQueueAttributesWithSomeAttributes() returns error? {
     };
     GetQueueAttributesResponse|Error result = sqsClient->getQueueAttributes(queueUrl, config);
     test:assertTrue(result is GetQueueAttributesResponse);
-    test:assertFalse(result is Error);
-    if result is error {
-        aws:ErrorDetails detail = result.detail();
-        test:assertEquals(detail.errorCode, "InvalidAttributeName");
-        test:assertEquals(detail.errorMessage, "Unknown Attribute FifoQueue.");
-        test:assertEquals(detail.httpStatusCode, 400);
-    }
 }
 
 @test:Config {

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -129,7 +129,7 @@ function testCreateQueueWithInvalidName() returns error? {
     string|Error result = sqsClient->createQueue(queueName);
     test:assertTrue(result is Error);
     if result is error {
-        ErrorDetails details = result.detail();
+        aws:ErrorDetails details = result.detail();
         test:assertEquals(details.errorCode, "InvalidParameterValue");
         test:assertEquals(details.httpStatusCode, 400);
         test:assertEquals(details.errorMessage, "Can only include alphanumeric characters, hyphens, or underscores. 1 to 80 in length");
@@ -149,7 +149,7 @@ function testCreateQueueWithInvalidAttributes() returns error? {
     string|Error result = sqsClient->createQueue(queueName, config);
     test:assertTrue(result is Error);
     if result is error {
-        ErrorDetails details = result.detail();
+        aws:ErrorDetails details = result.detail();
         test:assertEquals(details.errorCode, "InvalidAttributeValue");
         test:assertEquals(details.httpStatusCode, 400);
         test:assertEquals(details.errorMessage, "Invalid value for the parameter DelaySeconds.");
@@ -242,7 +242,7 @@ function testSendMessageToNonexistentQueue() returns error? {
     SendMessageResponse|Error result = sqsClient->sendMessage(queueUrl, message, sendMessageConfig);
     test:assertTrue(result is Error);
     if result is error {
-        ErrorDetails details = result.detail();
+        aws:ErrorDetails details = result.detail();
         test:assertEquals(details.httpStatusCode, 400);
         test:assertEquals(details.errorCode, "AWS.SimpleQueueService.NonExistentQueue");
         string? errorMessage = details.errorMessage;
@@ -264,7 +264,7 @@ function testSendMessageWithEmptyMessageBody() returns error? {
     SendMessageResponse|Error result = sqsClient->sendMessage(queueUrl, message);
     test:assertTrue(result is Error);
     if result is error {
-        ErrorDetails details = result.detail();
+        aws:ErrorDetails details = result.detail();
         test:assertEquals(details.httpStatusCode, 400);
         test:assertEquals(details.errorCode, "MissingParameter");
         test:assertEquals(details.errorMessage, "The request must contain the parameter MessageBody.");
@@ -284,7 +284,7 @@ function testSendMessageWithInvalidDelay() returns error? {
     SendMessageResponse|Error result = sqsClient->sendMessage(queueUrl, message, sendMessageConfig);
     test:assertTrue(result is Error);
     if result is error {
-        ErrorDetails details = result.detail();
+        aws:ErrorDetails details = result.detail();
         test:assertEquals(details.httpStatusCode, 400);
         test:assertEquals(details.errorCode, "InvalidParameterValue");
         test:assertEquals(details.errorMessage, "Value -1 for parameter DelaySeconds is invalid. Reason: DelaySeconds must be >= 0 and <= 900.");
@@ -304,7 +304,7 @@ function testSendMessageWithExcessiveDelay() returns error? {
     SendMessageResponse|Error result = sqsClient->sendMessage(queueUrl, message, sendMessageConfig);
     test:assertTrue(result is Error);
     if result is error {
-        ErrorDetails details = result.detail();
+        aws:ErrorDetails details = result.detail();
         test:assertEquals(details.httpStatusCode, 400);
         test:assertEquals(details.errorCode, "InvalidParameterValue");
         test:assertEquals(details.errorMessage, "Value 1000 for parameter DelaySeconds is invalid. Reason: DelaySeconds must be >= 0 and <= 900.");
@@ -329,7 +329,7 @@ function testSendMessageWithInvalidAttributes() returns error? {
     SendMessageResponse|Error result = sqsClient->sendMessage(queueUrl, message, sendMessageConfig);
     test:assertTrue(result is Error);
     if result is error {
-        ErrorDetails details = result.detail();
+        aws:ErrorDetails details = result.detail();
         test:assertEquals(details.httpStatusCode, 400);
         test:assertEquals(details.errorCode, "InvalidParameterValue");
         test:assertEquals(details.errorMessage, "The type of message (user) attribute 'invalidAttribute' is invalid. " +
@@ -397,7 +397,7 @@ function testSendMessageBatchWithDuplicatemessageId() returns error? {
     if result is SendMessageBatchResponse {
         test:assertFail("Expected error for duplicate message IDs, but got a successful response: " + result.toString());
     } else {
-        ErrorDetails details = result.detail();
+        aws:ErrorDetails details = result.detail();
         test:assertEquals(details.httpStatusCode, 400);
         test:assertEquals(details.errorCode, "AWS.SimpleQueueService.BatchEntryIdsNotDistinct");
         test:assertEquals(details.errorMessage, "Id idA repeated.");
@@ -439,7 +439,7 @@ function testSendMessageBatchExceedsLimit() returns error? {
     SendMessageBatchResponse|Error result = sqsClient->sendMessageBatch(queueUrl, entries);
     test:assertTrue(result is Error);
     if result is error {
-        ErrorDetails details = result.detail();
+        aws:ErrorDetails details = result.detail();
         test:assertEquals(details.httpStatusCode, 400);
         test:assertEquals(details.errorCode, "AWS.SimpleQueueService.TooManyEntriesInBatchRequest");
         test:assertEquals(details.errorMessage, "Maximum number of entries per request are 10. You have sent 11.");
@@ -456,7 +456,7 @@ function testSendMessageBatchWithEmptyList() returns error? {
     SendMessageBatchResponse|Error result = sqsClient->sendMessageBatch(queueUrl, entries);
     test:assertTrue(result is Error);
     if result is error {
-        ErrorDetails details = result.detail();
+        aws:ErrorDetails details = result.detail();
         test:assertEquals(details.httpStatusCode, 400);
         test:assertEquals(details.errorCode, "AWS.SimpleQueueService.EmptyBatchRequest");
         test:assertEquals(details.errorMessage, "There should be at least one SendMessageBatchRequestEntry in the request.");
@@ -485,7 +485,7 @@ function testSendMessageBatchExceedsTotalSizeLimit() returns error? {
     SendMessageBatchResponse|Error result = sqsClient->sendMessageBatch(queueUrl, entries);
     test:assertTrue(result is Error);
     if result is error {
-        ErrorDetails details = result.detail();
+        aws:ErrorDetails details = result.detail();
         test:assertEquals(details.httpStatusCode, 400);
         test:assertEquals(details.errorCode, "AWS.SimpleQueueService.BatchRequestTooLong");
         test:assertEquals(details.errorMessage, "Batch requests cannot be longer than 1048576 bytes. You have sent 1048580 bytes.");
@@ -541,7 +541,7 @@ isolated function testReceiveMessageInvalidQueueUrl() returns error? {
     Message[]|Error result = sqsClient->receiveMessage(queueUrl);
     test:assertTrue(result is Error);
     if result is error {
-        ErrorDetails details = result.detail();
+        aws:ErrorDetails details = result.detail();
         test:assertEquals(details.httpStatusCode, 404);
         test:assertEquals(details.errorCode, "InvalidAddress");
     }
@@ -559,7 +559,7 @@ function testReceiveMessageInvalidMaxMessages() returns error? {
     Message[]|Error result = sqsClient->receiveMessage(queueUrl, config);
     test:assertTrue(result is Error);
     if result is error {
-        ErrorDetails details = result.detail();
+        aws:ErrorDetails details = result.detail();
         test:assertEquals(details.httpStatusCode, 400);
         test:assertEquals(details.errorCode, "InvalidParameterValue");
     }
@@ -607,7 +607,7 @@ function testDeleteMessageWithInvalidReceiptHandle() returns error? {
     Error? deleteResult = sqsClient->deleteMessage(queueUrl, fakeReceiptHandle);
     test:assertTrue(deleteResult is Error);
     if deleteResult is error {
-        ErrorDetails details = deleteResult.detail();
+        aws:ErrorDetails details = deleteResult.detail();
         test:assertEquals(details.httpStatusCode, 404);
         test:assertEquals(details.errorCode, "ReceiptHandleIsInvalid");
     }
@@ -690,7 +690,7 @@ function testDeleteMessageBatchWithDuplicateIds() returns error? {
     DeleteMessageBatchResponse|Error result = sqsClient->deleteMessageBatch(queueUrl, entries);
     test:assertTrue(result is Error);
     if result is error {
-        ErrorDetails details = result.detail();
+        aws:ErrorDetails details = result.detail();
         test:assertEquals(details.errorCode, "AWS.SimpleQueueService.BatchEntryIdsNotDistinct");
         test:assertEquals(details.httpStatusCode, 400);
         test:assertEquals(details.errorMessage, "Id dup-id repeated.");
@@ -725,7 +725,7 @@ function testSetQueueAttribuesWithInvalidDelay() returns error? {
     Error? result = sqsClient->setQueueAttributes(queueUrl, attributes);
     test:assertTrue(result is Error);
     if result is error {
-        ErrorDetails details = result.detail();
+        aws:ErrorDetails details = result.detail();
         test:assertEquals(details.errorCode, "InvalidAttributeValue");
         test:assertEquals(details.httpStatusCode, 400);
         test:assertEquals(details.errorMessage, "Invalid value for the parameter DelaySeconds.");
@@ -766,7 +766,7 @@ function testGetQueueAttributesWithSomeAttributes() returns error? {
     test:assertTrue(result is GetQueueAttributesResponse);
     test:assertFalse(result is Error);
     if result is error {
-        ErrorDetails detail = result.detail();
+        aws:ErrorDetails detail = result.detail();
         test:assertEquals(detail.errorCode, "InvalidAttributeName");
         test:assertEquals(detail.errorMessage, "Unknown Attribute FifoQueue.");
         test:assertEquals(detail.httpStatusCode, 400);
@@ -865,7 +865,7 @@ isolated function testGetNonExistentQueueUrl() returns error? {
     string|Error? result = sqsClient->getQueueUrl(queueName);
     test:assertTrue(result is Error);
     if result is error {
-        ErrorDetails details = result.detail();
+        aws:ErrorDetails details = result.detail();
         test:assertEquals(details.errorCode, "AWS.SimpleQueueService.NonExistentQueue");
         test:assertEquals(details.errorMessage, "The specified queue does not exist.");
         test:assertEquals(details.httpStatusCode, 400);
@@ -898,7 +898,7 @@ function testTagQueueWithEmptyTagKey() returns error? {
     Error? result = sqsClient->tagQueue(queueUrl, tags);
     test:assertTrue(result is Error);
     if result is error {
-        ErrorDetails details = result.detail();
+        aws:ErrorDetails details = result.detail();
         test:assertEquals(details.errorCode, "InvalidParameterValue");
         test:assertEquals(details.httpStatusCode, 400);
         test:assertEquals(details.errorMessage, "Tag keys must be between 1 and 128 characters in length.");
@@ -1055,7 +1055,7 @@ isolated function testDeleteNonExistentQueue() returns error? {
     Error? result = sqsClient->deleteQueue(queueUrl);
     test:assertTrue(result is Error, "Expected unsuccessful deletion.");
     if result is error {
-        ErrorDetails details = result.detail();
+        aws:ErrorDetails details = result.detail();
         test:assertEquals(details.errorCode, "AWS.SimpleQueueService.NonExistentQueue");
         test:assertEquals(details.httpStatusCode, 400);
         string? errorMessage = details.errorMessage;

--- a/changelog.md
+++ b/changelog.md
@@ -20,12 +20,18 @@ It contains breaking changes. See the "Migrating from 4.x" section below.
 - **[Breaking]** The `ConnectionConfig.region` field type changed from `sqs:Region` to `aws:Region|string`.
   The `string` alternative allows regions that are not yet present in the `aws:Region` enum to be supplied
   directly.
+- **[Breaking]** The detail type of `sqs:Error` changed from `sqs:ErrorDetails` to `aws:ErrorDetails`, so that
+  all AWS connectors report failures through a single, shared error detail record. The two records have
+  identical fields, so field access on the value returned by `error.detail()` continues to work unchanged —
+  only explicit `sqs:ErrorDetails` type references need updating.
 
 ### Removed
 - **[Breaking]** `sqs:StaticAuthConfig`, `sqs:ProfileAuthConfig` and `sqs:DEFAULT_CREDENTIALS` have been
   removed in favour of the `ballerinax/aws.auth` equivalents. The replacement records are structurally
   identical to the ones they replace, so inline record literals continue to work unchanged — only explicit
   type references need updating.
+- **[Breaking]** `sqs:ErrorDetails` has been removed in favour of `aws:ErrorDetails`. The replacement record
+  is structurally identical to the one it replaces.
 - **[Breaking]** The `sqs:Region` enum has been removed in favour of `aws:Region`. The following members
   have no `aws:Region` equivalent and must now be supplied as plain region strings
   (for example, `region: "us-iso-east-1"`):
@@ -51,7 +57,7 @@ It contains breaking changes. See the "Migrating from 4.x" section below.
 - A new optional `ConnectionConfig.endpoint` field of type `aws:EndpointConfig`, for selecting FIPS or
   dualstack endpoint variants and for overriding the endpoint entirely (for example, LocalStack or VPC
   interface endpoints).
-- A new optional `requestId` field on `ErrorDetails`, carrying the AWS request ID of the failed call to
+- A new optional `requestId` field on `aws:ErrorDetails`, carrying the AWS request ID of the failed call to
   simplify support escalations.
 - New `aws:Region` members not present in the former `sqs:Region` enum: `AP_EAST_2`, `AP_SOUTHEAST_5`,
   `AP_SOUTHEAST_7` and `MX_CENTRAL_1`.
@@ -98,6 +104,25 @@ import ballerinax/aws.auth;
 auth:StaticAuthConfig authConfig = {accessKeyId, secretAccessKey};
 auth:ProfileAuthConfig authConfig = {profileName: "dev"};
 sqs:ConnectionConfig config = {region: aws:US_EAST_1, auth: auth:DEFAULT_CREDENTIALS};
+```
+
+Code that named `sqs:ErrorDetails` when inspecting an error must use `aws:ErrorDetails` instead. Field
+access is unchanged:
+
+```ballerina
+// 4.x
+if result is sqs:Error {
+    sqs:ErrorDetails details = result.detail();
+    io:println(details.errorCode);
+}
+```
+
+```ballerina
+// 5.0.0
+if result is sqs:Error {
+    aws:ErrorDetails details = result.detail();
+    io:println(details.errorCode);
+}
 ```
 
 Configurations that used one of the removed `Region` members should supply the region string directly:

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ apacheHttpClientVersion=4.5.14
 reactiveStreamsVersion=1.0.4
 
 stdlibTimeVersion=2.6.0
-stdlibAwsVersion=0.1.0
+stdlibAwsVersion=0.2.0

--- a/native/src/main/java/io/ballerina/lib/aws/sqs/CommonUtils.java
+++ b/native/src/main/java/io/ballerina/lib/aws/sqs/CommonUtils.java
@@ -16,18 +16,12 @@
 
 package io.ballerina.lib.aws.sqs;
 
-import java.util.Objects;
-
+import io.ballerina.lib.aws.ErrorUtils;
 import io.ballerina.runtime.api.creators.ErrorCreator;
-import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
-
-import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
-import software.amazon.awssdk.awscore.exception.AwsServiceException;
-import software.amazon.awssdk.http.SdkHttpResponse;
 
 /**
  * {@code CommonUtils} Contains the common utility functions for the Ballerina
@@ -37,45 +31,28 @@ import software.amazon.awssdk.http.SdkHttpResponse;
 public final class CommonUtils {
 
     private static final String ERROR = "Error";
-    private static final String ERROR_DETAILS = "ErrorDetails";
-    private static final BString ERROR_DETAILS_HTTP_STATUS_CODE = StringUtils.fromString("httpStatusCode");
-    private static final BString ERROR_DETAILS_HTTP_STATUS_TEXT = StringUtils.fromString("httpStatusText");
-    private static final BString ERROR_DETAILS_ERROR_CODE = StringUtils.fromString("errorCode");
-    private static final BString ERROR_DETAILS_ERROR_MESSAGE = StringUtils.fromString("errorMessage");
-    private static final BString ERROR_DETAILS_REQUEST_ID = StringUtils.fromString("requestId");
 
     private CommonUtils() {
     }
 
+    /**
+     * Creates an {@code sqs:Error} carrying the shared {@code ballerinax/aws:ErrorDetails}
+     * built from the given exception.
+     */
     public static BError createError(String message, Throwable exception) {
         BError cause = ErrorCreator.createError(exception);
-        BMap<BString, Object> errorDetails = ValueCreator.createRecordValue(
-                ModuleUtils.getModule(), ERROR_DETAILS);
-        if (exception instanceof AwsServiceException awsServiceException &&
-                Objects.nonNull(awsServiceException.awsErrorDetails())) {
-            AwsErrorDetails awsErrorDetails = awsServiceException.awsErrorDetails();
-            SdkHttpResponse sdkResponse = awsErrorDetails.sdkHttpResponse();
-            if (Objects.nonNull(sdkResponse)) {
-                errorDetails.put(ERROR_DETAILS_HTTP_STATUS_CODE, sdkResponse.statusCode());
-                sdkResponse.statusText().ifPresent(httpStatusTxt -> errorDetails.put(
-                        ERROR_DETAILS_HTTP_STATUS_TEXT, StringUtils.fromString(httpStatusTxt)));
-            }
-            if (Objects.nonNull(awsErrorDetails.errorCode())) {
-                errorDetails.put(ERROR_DETAILS_ERROR_CODE, StringUtils.fromString(awsErrorDetails.errorCode()));
-            }
-            if (Objects.nonNull(awsErrorDetails.errorMessage())) {
-                errorDetails.put(ERROR_DETAILS_ERROR_MESSAGE,
-                        StringUtils.fromString(awsErrorDetails.errorMessage()));
-            }
-            if (Objects.nonNull(awsServiceException.requestId())) {
-                errorDetails.put(ERROR_DETAILS_REQUEST_ID, StringUtils.fromString(awsServiceException.requestId()));
-            }
-        }
+        BMap<BString, Object> errorDetails = ErrorUtils.createErrorDetails(exception);
         return ErrorCreator.createError(
                 ModuleUtils.getModule(), ERROR, StringUtils.fromString(message), cause, errorDetails);
     }
 
+    /**
+     * Creates an {@code sqs:Error} for a failure that did not originate from an AWS
+     * service call, hence with all the {@code ballerinax/aws:ErrorDetails} fields unset.
+     */
     public static BError createError(String message) {
-        return ErrorCreator.createError(ModuleUtils.getModule(), ERROR, StringUtils.fromString(message), null, null);
+        BMap<BString, Object> errorDetails = ErrorUtils.createErrorDetails(null);
+        return ErrorCreator.createError(
+                ModuleUtils.getModule(), ERROR, StringUtils.fromString(message), null, errorDetails);
     }
 }


### PR DESCRIPTION
## Purpose

Part of: https://github.com/wso2-enterprise/integration-engineering/issues/2091 

## Examples

## Checklist
- [X] Linked to an issue
- [X] Updated the changelog
- [X] Added tests
- [X] Updated the spec
- [X] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Updated the SQS module to use the shared `aws:ErrorDetails` record for error details consistency across the API and native runtime.
- Refactored native SQS error creation to centralize error-detail extraction via shared `ErrorUtils`, improving alignment with the new error model.
- Updated negative test cases to reference `aws:ErrorDetails` explicitly, and bumped related AWS dependency versions for compatibility.
- Refreshed related build/native-image compatibility settings (GraalVM) and documentation to match the updated error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->