### PR TITLE
Bump `ballerinax/aws` Version

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -111,7 +111,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "aws"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/changelog.md
+++ b/changelog.md
@@ -32,21 +32,7 @@ It contains breaking changes. See the "Migrating from 4.x" section below.
   type references need updating.
 - **[Breaking]** `sqs:ErrorDetails` has been removed in favour of `aws:ErrorDetails`. The replacement record
   is structurally identical to the one it replaces.
-- **[Breaking]** The `sqs:Region` enum has been removed in favour of `aws:Region`. The following members
-  have no `aws:Region` equivalent and must now be supplied as plain region strings
-  (for example, `region: "us-iso-east-1"`):
-
-  | Removed member | Region string |
-  | --- | --- |
-  | `AWS_GLOBAL` | `aws-global` |
-  | `AWS_CN_GLOBAL` | `aws-cn-global` |
-  | `AWS_US_GOV_GLOBAL` | `aws-us-gov-global` |
-  | `AWS_ISO_GLOBAL` | `aws-iso-global` |
-  | `AWS_ISO_B_GLOBAL` | `aws-iso-b-global` |
-  | `US_ISO_EAST_1` | `us-iso-east-1` |
-  | `US_ISO_WEST_1` | `us-iso-west-1` |
-  | `US_ISOB_EAST_1` | `us-isob-east-1` |
-  | `EU_ISOE_WEST_1` | `eu-isoe-west-1` |
+- **[Breaking]** The `sqs:Region` enum has been removed in favour of `aws:Region`.
 
 ### Added
 - Support for four additional AWS credential sources, available through `auth:AuthConfig`:

--- a/changelog.md
+++ b/changelog.md
@@ -111,18 +111,6 @@ if result is sqs:Error {
 }
 ```
 
-Configurations that used one of the removed `Region` members should supply the region string directly:
-
-```ballerina
-// 4.x
-sqs:ConnectionConfig config = {region: sqs:US_ISO_EAST_1, auth: authConfig};
-```
-
-```ballerina
-// 5.0.0
-sqs:ConnectionConfig config = {region: "us-iso-east-1", auth: authConfig};
-```
-
 ## [4.1.0] - 2026-02-26
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ apacheHttpClientVersion=4.5.14
 reactiveStreamsVersion=1.0.4
 
 stdlibTimeVersion=2.6.0
-stdlibAwsVersion=0.2.0
+stdlibAwsVersion=1.0.0


### PR DESCRIPTION
## Purpose

Part of: https://github.com/wso2-enterprise/integration-engineering/issues/2091 

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated the `ballerinax/aws` module version from `0.2.0` to `1.0.0` in dependency and Gradle configuration.
- Simplified the changelog entry describing the replacement of `sqs:Region` with `aws:Region`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->